### PR TITLE
feat: add arguments to fzf command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,11 @@ use std::str;
 /// Prompts the user to select the item in the CLI using the fzf tool.
 /// It's required that fzf is installed in the environment.
 pub fn fzf_select(fzf_input: Vec<String>) -> String {
+    fzf_select_with_args(fzf_input, Vec::new())
+}
+pub fn fzf_select_with_args(fzf_input: Vec<String>, args: Vec<String>) -> String {
     let mut child = Command::new("fzf")
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,7 @@ use std::str;
 
 /// Prompts the user to select the item in the CLI using the fzf tool.
 /// It's required that fzf is installed in the environment.
-pub fn fzf_select(fzf_input: Vec<String>) -> String {
-    fzf_select_with_args(fzf_input, Vec::new())
-}
-pub fn fzf_select_with_args(fzf_input: Vec<String>, args: Vec<String>) -> String {
+pub fn fzf_select(fzf_input: Vec<String>, args: Vec<String>) -> String {
     let mut child = Command::new("fzf")
         .args(args)
         .stdin(Stdio::piped())
@@ -37,7 +34,7 @@ mod tests {
     #[test]
     fn test_fzf_select() {
         let test_input = vec!["test".to_string(), "me".to_string()];
-        let output = fzf_select(test_input);
+        let output = fzf_select(test_input, Vec::new());
         assert_eq!("test", output);
     }
 }


### PR DESCRIPTION
added function `fzf_select_with_args` which allows to pass a list of arguments for `fzf`.
`fzf_select` calls `fzf_select_with_args` with an empty list for backward compatibility.